### PR TITLE
fix: RT#121287 avoid duplicate SIGNATURE entry in MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,6 @@ Build.PL
 MANIFEST
 MANIFEST.SKIP
 README
-SIGNATURE
 lib/WWW/Wookie.pm
 lib/WWW/Wookie/Connector/Exceptions.pm
 lib/WWW/Wookie/Connector/Service/Interface.pm


### PR DESCRIPTION
Drop the dummy SIGNATURE in the repo and let Module::Build add it.